### PR TITLE
Fix description for proxy_port C2 profile parameter in v3.0.0

### DIFF
--- a/C2_Profiles/http/http/c2functions/builder.go
+++ b/C2_Profiles/http/http/c2functions/builder.go
@@ -135,7 +135,7 @@ var httpc2parameters = []c2structs.C2Parameter{
 	},
 	{
 		Name:          "proxy_port",
-		Description:   "Name of the query parameter for GET requests",
+		Description:   "Proxy Port",
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
 		Required:      false,


### PR DESCRIPTION
The description in the v3.0.0 branch for the proxy_port value is incorrect. This fixes the description to match the master branch.

![image](https://user-images.githubusercontent.com/13649965/224589966-a34818ca-751f-4915-8f74-868136a9f84d.png)